### PR TITLE
Fixed import statement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ npm i parentsuntil
 
 ## Usage
 ```
-import parentsUntil from 'parentsUntil'
+import parentsUntil from 'parentsuntil'
 
 var elem = document.querySelector('#some-element');
 var parentsUntil = parentsUntil(elem, '.some-class');


### PR DESCRIPTION
With the import statement from the README the import was not possible, since the package is named only in lower case. Maybe it would work when building everythig in Windows, but in Linux it doesn't.